### PR TITLE
Fix regex matching.

### DIFF
--- a/sdk_updater/list.py
+++ b/sdk_updater/list.py
@@ -43,7 +43,7 @@ def list_packages(android):
         if m is None:
             print("Failed to parse revision:", field, file=sys.stderr)
             continue
-        revision, _ = m.groups()
+        revision, = m.groups()
         revision = revision.replace(' (Obsolete)', '')
         semver = Version.coerce(revision)
 


### PR DESCRIPTION
You merged as I was still working on this.

I believe this is now working in Python 2.7.10. Here is the output I'm getting:

```
(android-sdk-updater)pierrot:src tristan$ android-sdk-updater 
Scanning /Users/tristan/.android-sdk for installed packages...
Package parse failed: /add-ons/addon-google_apis-google-15
Package parse failed: /add-ons/addon-google_apis-google-16
Package parse failed: /add-ons/addon-google_apis-google-17
Package parse failed: /add-ons/addon-google_apis-google-18
Package parse failed: /add-ons/addon-google_apis-google-19
Package parse failed: /add-ons/addon-google_apis-google-21
Package parse failed: /add-ons/addon-google_apis-google-22
Package parse failed: /add-ons/addon-google_apis-google-23
Package parse failed: /add-ons/addon-google_apis_x86-google-19
Package parse failed: /add-ons/addon-google_gdk-google-19
Package parse failed: /build-tools/17.0.0
Package parse failed: /build-tools/18.0.1
Package parse failed: /build-tools/18.1.0
Package parse failed: /build-tools/18.1.1
Package parse failed: /build-tools/19.0.0
Package parse failed: /build-tools/19.0.1
Package parse failed: /build-tools/19.0.2
Package parse failed: /build-tools/19.0.3
Package parse failed: /build-tools/19.1.0
Package parse failed: /build-tools/21.0.0
Package parse failed: /build-tools/21.0.1
Package parse failed: /build-tools/21.0.2
Package parse failed: /build-tools/21.1.0
Package parse failed: /build-tools/21.1.1
Package parse failed: /build-tools/21.1.2
Package parse failed: /build-tools/22.0.0
Package parse failed: /build-tools/22.0.1
Package parse failed: /build-tools/23.0.0
Package parse failed: /build-tools/23.0.1
Package parse failed: /build-tools/23.0.2
Package parse failed: /build-tools/android-4.4W
Package parse failed: /docs
Package parse failed: /extras/android/m2repository
Package parse failed: /extras/android/support
Package parse failed: /extras/google/google_play_services
Package parse failed: /extras/google/m2repository
Package parse failed: /extras/intel/Hardware_Accelerated_Execution_Manager
Package parse failed: /platform-tools
Package parse failed: /platforms/android-15
Package parse failed: /platforms/android-16
Package parse failed: /platforms/android-17
Package parse failed: /platforms/android-18
Package parse failed: /platforms/android-19
Package parse failed: /platforms/android-20
Package parse failed: /platforms/android-21
Package parse failed: /platforms/android-22
Package parse failed: /platforms/android-23
Package parse failed: /platforms/android-L
Package parse failed: /platforms/android-MNC
Package parse failed: /samples/android-22
Package parse failed: /samples/android-23
Package parse failed: /samples/android-MNC
Package parse failed: /sources/android-15
Package parse failed: /sources/android-16
Package parse failed: /sources/android-17
Package parse failed: /sources/android-18
Package parse failed: /sources/android-19
Package parse failed: /sources/android-21
Package parse failed: /sources/android-22
Package parse failed: /sources/android-23
Package parse failed: /system-images/android-15/default/armeabi-v7a
Package parse failed: /system-images/android-15/default/x86
Package parse failed: /system-images/android-16/default/armeabi-v7a
Package parse failed: /system-images/android-17/default/armeabi-v7a
Package parse failed: /system-images/android-17/default/x86
Package parse failed: /system-images/android-18/default/armeabi-v7a
Package parse failed: /system-images/android-18/default/x86
Package parse failed: /system-images/android-19/default/armeabi-v7a
Package parse failed: /system-images/android-19/default/x86
Package parse failed: /system-images/android-20/android-wear/armeabi-v7a
Package parse failed: /system-images/android-20/android-wear/x86
Package parse failed: /system-images/android-21/android-tv/armeabi-v7a
Package parse failed: /system-images/android-21/android-tv/x86
Package parse failed: /system-images/android-21/default/armeabi-v7a
Package parse failed: /system-images/android-21/default/x86
Package parse failed: /system-images/android-21/default/x86_64
Package parse failed: /system-images/android-21/google_apis/armeabi-v7a
Package parse failed: /system-images/android-21/google_apis/x86
Package parse failed: /system-images/android-21/google_apis/x86_64
Package parse failed: /system-images/android-22/android-tv/armeabi-v7a
Package parse failed: /system-images/android-22/android-tv/x86
Package parse failed: /system-images/android-22/default/armeabi-v7a
Package parse failed: /system-images/android-22/default/x86
Package parse failed: /system-images/android-22/default/x86_64
Package parse failed: /system-images/android-22/google_apis/armeabi-v7a
Package parse failed: /system-images/android-22/google_apis/x86
Package parse failed: /system-images/android-22/google_apis/x86_64
Package parse failed: /system-images/android-23/android-tv/armeabi-v7a
Package parse failed: /system-images/android-23/android-tv/x86
Package parse failed: /system-images/android-23/default/armeabi-v7a
Package parse failed: /system-images/android-23/default/x86
Package parse failed: /system-images/android-23/default/x86_64
Package parse failed: /system-images/android-23/google_apis/armeabi-v7a
Package parse failed: /system-images/android-23/google_apis/x86
Package parse failed: /system-images/android-23/google_apis/x86_64
Package parse failed: /system-images/android-L/default/armeabi-v7a
Package parse failed: /system-images/android-L/default/x86
Package parse failed: /system-images/android-L/default/x86_64
Package parse failed: /system-images/android-MNC/default/arm64-v8a
Package parse failed: /system-images/android-MNC/default/armeabi-v7a
Package parse failed: /system-images/android-MNC/default/x86
Package parse failed: /system-images/android-MNC/default/x86_64
Package parse failed: /tools
    0 packages installed.
Querying update sites for available packages...
    160 packages available.
All packages are up-to-date.
```
