### PR TITLE
Decode using UTF-8 instead of ascii.

### DIFF
--- a/sdk_updater/list.py
+++ b/sdk_updater/list.py
@@ -35,7 +35,7 @@ def list_packages(android, options=None, verbose=False):
         [android, 'list', 'sdk', '--all', '--extended'] + options,
         stderr=subprocess.PIPE)
 
-    out = out.decode()
+    out = out.decode('utf-8')
 
     if verbose:
         print(out)


### PR DESCRIPTION
This was causing failures on 2.7.
