### PR TITLE
Exit with failure when packages fail to install

### DIFF
--- a/sdk_updater/update.py
+++ b/sdk_updater/update.py
@@ -144,9 +144,10 @@ def main(sdk, bootstrap=None, options=None, verbose=False, timeout=None, dry_run
     if missing:
         print('Finished: {:d} packages installed. Failed to install {:d} packages.'
               .format(len(to_install) - len(missing), len(missing)))
+        exit(1)
     else:
         print('Finished: {:d} packages installed.'.format(len(to_install)))
-
+        exit(0)
 
 if __name__ == '__main__':
     main(sys.argv[1:])


### PR DESCRIPTION
Fixes #16 

```
tad-fisher:sdk tad$ android-sdk-updater -a . android-21
Scanning . for installed packages...
Ignoring 'ndk-bundle' as it is blacklisted.
    10 packages installed.
Querying update sites for available packages...
    160 packages available.
Installing: android-21 [2]
Re-scanning ....
Ignoring 'ndk-bundle' as it is blacklisted.
Failed to install packages:
    android-21 [2]
Finished: 0 packages installed. Failed to install 1 packages.
tad-fisher:sdk tad$ echo $?
1
```
