### PR TITLE
Handle Symlinks for brew installed android sdks

### DIFF
--- a/sdk_updater/scan.py
+++ b/sdk_updater/scan.py
@@ -114,7 +114,7 @@ def parse_properties(file):
 
 def scan(top, verbose=False):
     packages = []
-    for root, subdirs, files in os.walk(top):
+    for root, subdirs, files in os.walk(top, followlinks=True):
         if 'source.properties' in files:
             del subdirs[:]
             package = parse(top, root)


### PR DESCRIPTION
## What this does
- When you `brew install android-sdk` a lot of the folders end up being symlinks
- `os.walk()` does not handle symlinks without `followLinks=True`
- This means that installation always failed, now it does not.
