### PR TITLE
Add and handle --show commands

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -75,7 +75,7 @@ Usage
 ::
 
     usage: android-sdk-updater [-h] [-v] [-a ANDROID_HOME] [-d] [-t TIMEOUT] [-vv]
-                               [-o ...]
+                               [-o ...] [-s {available,installed,updates}]
                                [package [package ...]]
 
     Update an Android SDK installation
@@ -97,7 +97,9 @@ Usage
       -vv, --verbose        show extra output from android tools
       -o ..., --options ...
                             options to pass to the "android" tool; must be the
-                            final argument specified
+                            final option specified
+      -s {available,installed,updates}, --show {available,installed,updates}
+                            Show available or installed packages
 
 Additional whitespace-delimited :code:`package` arguments can be piped to this tool over the standard input.
 
@@ -136,6 +138,14 @@ Update all packages in :code:`ANDROID_HOME` and ensure the installation of packa
 Same as the above, but through a proxy::
 
     $ cat packages.txt | android-sdk-updater -o --no-https --proxy-host example.com --proxy-port 3218
+
+Show installed packages, available packags, or packages with updates::
+
+    $ android-sdk-updater -s installed
+
+    $ android-sdk-updater -s available
+    
+    $ android-sdk-updater -s updates
 
 Caveats
 -------

--- a/bin/android-sdk-updater
+++ b/bin/android-sdk-updater
@@ -8,7 +8,50 @@ import sys
 
 from sdk_updater import __version__
 from sdk_updater import update as update_sdk
+from sdk_updater.scan import scan
+from sdk_updater.list import list_packages
+from sdk_updater.update import updates_available
 
+def show(android_home, args):
+    android = os.path.join(android_home, 'tools', 'android')
+
+    if args.show == "installed":
+        print("Installed packages:\n===================")
+        packages = scan(android_home, verbose=args.verbose)
+    elif args.show == "updates":
+        print("Available updates:\n===================")
+        ops, missing = updates_available(android,
+                                     android_home, 
+                                     packages=None, 
+                                     options=None, 
+                                     verbose=args.verbose)
+        packages = [op.package for op in ops]
+    else:
+        print("Available packages:\n===================")
+        packages = list_packages(android, 
+                                 options=args.options, 
+                                 verbose=args.verbose)
+
+    if packages is not None and packages:
+        names = [p.name for p in packages]
+        print("\n".join(names))
+    else:
+        print("No Packages")
+
+def default(android_home, args):
+    # Read packages from stdin
+    packages = list(args.package)
+    if not sys.stdin.isatty():
+        for line in sys.stdin:
+            packages.extend(line.split())
+
+    # Run the updater
+    update_sdk.main(android_home,
+                    packages=packages,
+                    options=args.options,
+                    verbose=args.verbose,
+                    timeout=args.timeout,
+                    dry_run=args.dry_run)
 
 def main():
     # Create our parser
@@ -31,6 +74,8 @@ def main():
                         help='options to pass to the "android" tool; must be the final option specified')
     parser.add_argument('package', nargs='*',
                         help='name of SDK package to install if not already installed')
+    parser.add_argument('-s', '--show', choices=['available', 'installed', 'updates'],
+                        help='Show available or installed packages')
 
     # Get our arguments
     args = parser.parse_args()
@@ -47,20 +92,11 @@ def main():
     if args.timeout < 0:
         parser.error('Timeout must be a positive number of seconds')
 
-    # Read packages from stdin
-    packages = list(args.package)
-    if not sys.stdin.isatty():
-        for line in sys.stdin:
-            packages.extend(line.split())
-
-    # Run the updater
-    update_sdk.main(android_home,
-                    packages=packages,
-                    options=args.options,
-                    verbose=args.verbose,
-                    timeout=args.timeout,
-                    dry_run=args.dry_run)
-
+    if args.show:
+        show(android_home, args)
+    else: # Default Action
+        default(android_home, args)
+        
 
 if __name__ == '__main__':
     try:


### PR DESCRIPTION
## What this is
- An attempt at addressing the show actions in https://github.com/tadfisher/android-sdk-updater/issues/13
- Available commands:
  - `android-sdk-updater --show installed`
  - `android-sdk-updater --show updates`
  - `android-sdk-updater --show available`
- I know the issue had `show`, but `--show` was significantly easier - however I am very much new to Python and spend most of my time in Ruby-land, so if you know a way to make this work without affecting the original commands. That'd be awesome!
- This does not affect (or should not affect) the way commands are currently run.
## Example output

Available:

```
➜ android-sdk-updater --show available
Available packages:
===================
tools
tools-preview
platform-tools
platform-tools-preview
build-tools-24.0.0-preview
build-tools-23.0.2
...
```

Updates:

```
➜ android-sdk-updater --show updates
Available updates:
===================
Scanning /usr/local/opt/android-sdk for installed packages...
    25 packages installed.
Querying update sites for available packages...
    166 packages available.
No Packages
```

Installed:

```
➜ android-sdk-updater --show installed
Installed packages:
===================
addon-google_apis-google-23
extra-android-gapid
extra-android-m2repository
extra-android-support
...
```
