### PR TITLE
Fix Android SDK for sys img's naming conflict

### DIFF
--- a/sdk_updater/scan.py
+++ b/sdk_updater/scan.py
@@ -55,8 +55,6 @@ def system_images(props, parts):
     tag = props['tag']
     if tag == 'default':
         tag = 'android'
-    if tag == 'google_apis':
-        tag = 'addon-google_apis-google'
     return '-'.join(['sys-img', props['abi'], tag, props['api']])
 
 


### PR DESCRIPTION
Android now installs sys images via the format sys-img-x86_64-google_apis-21
But it used to use sys-img-x86_64-addon-google_apis-google-21
This causes conflicts. Fix the tag.
## Before

```
Failed to install packages:
    sys-img-x86_64-google_apis-21
    sys-img-x86_64-google_apis-23
    sys-img-x86_64-google_apis-22

Installed:
sys-img-x86_64-addon-google_apis-google-21
sys-img-x86_64-addon-google_apis-google-22
sys-img-x86_64-addon-google_apis-google-23
```
## After

```
Installed:
sys-img-x86_64-google_apis-21
sys-img-x86_64-google_apis-22
sys-img-x86_64-google_apis-23
```
