### PR TITLE
Don't exit fatally when remote missing implicit packages

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,6 +3,18 @@
 Change Log
 ----------
 
+0.0.4 (2016-07-24)
+++++++++++++++++++
+
+**Bugfixes**
+
+- Display a warning for missing remote packages instead of exiting fatally.
+- Exit fatally when the remote is missing explicitly-requested packages.
+- Standardize error messaging:
+  - Prepend "WARNING:" for non-fatal messages
+  - Prepend "FATAL:" for fatal messages
+
+
 0.0.3 (2016-04-16)
 ++++++++++++++++++
 
@@ -26,6 +38,7 @@ Change Log
 - Handle Unicode strings properly for Python 2.
 - Blacklist the NDK package. Plans are in place to support this in a future release.
 - Use non-zero exit code when installation of one or more packages fail.
+
 
 0.0.1 (2015-11-27)
 ++++++++++++++++++

--- a/sdk_updater/__init__.py
+++ b/sdk_updater/__init__.py
@@ -1,12 +1,12 @@
 """
 android-sdk-updater
 
-:copyright: (c) 2015 Tad Fisher
+:copyright: (c) 2016 Tad Fisher
 :license: Apache 2.0, see LICENSE for more details.
 
 """
 
-__version__ = '0.0.3'
+__version__ = '0.0.4'
 __author__ = 'Tad Fisher'
 __license__ = 'Apache 2.0'
 __copyright__ = 'Copyright 2016 Tad Fisher'

--- a/sdk_updater/list.py
+++ b/sdk_updater/list.py
@@ -47,12 +47,12 @@ def list_packages(android, options=None, verbose=False):
     for field in fields:
         m = p_id.search(field)
         if m is None:
-            print("Failed to parse package ID:", field, file=sys.stderr)
+            print("WARNING: Failed to parse package ID:", field, file=sys.stderr)
             continue
         num, name = m.groups()
         m = p_revision.search(field)
         if m is None:
-            print("Failed to parse revision:", field, file=sys.stderr)
+            print("WARNING: Failed to parse revision:", field, file=sys.stderr)
             continue
         revision, = m.groups()
         revision = revision.replace(' (Obsolete)', '')
@@ -60,12 +60,12 @@ def list_packages(android, options=None, verbose=False):
 
         m = p_type.search(field)
         if m is None:
-            print('Failed to parse type:', field, file=sys.stderr)
+            print('WARNING: Failed to parse type:', field, file=sys.stderr)
             continue
         ptype, = m.groups()
         category = categories[ptype]
         if category is None:
-            print('Unrecognized type:', ptype, file=sys.stderr)
+            print('WARNING: Unrecognized type:', ptype, file=sys.stderr)
             category = ptype.lower()
         packages.append(Package(category, name, revision, semver, num))
     return packages

--- a/sdk_updater/scan.py
+++ b/sdk_updater/scan.py
@@ -71,7 +71,7 @@ def parse(top, root):
     parts = path.split(os.path.sep)
 
     if parts[0] in blacklist:
-        print('Ignoring \'{:s}\' as it is blacklisted.'.format(path))
+        print('WARNING: Ignoring \'{:s}\' as it is blacklisted.'.format(path), file=sys.stderr)
         return None
 
     props = parse_properties(os.path.join(root, 'source.properties'))
@@ -88,7 +88,7 @@ def parse(top, root):
         'tools': tools
     }.get(parts[0], default)(props, parts)
     if not name:
-        print("Package parse failed:", path, file=sys.stderr)
+        print("WARNING: Failed to parse package:", path, file=sys.stderr)
         return None
     return Package(parts[0], name, props['revision'], Version.coerce(props['revision']))
 

--- a/sdk_updater/update.py
+++ b/sdk_updater/update.py
@@ -72,12 +72,7 @@ def scan_missing(sdk, packages, verbose=False):
     # Re-scan SDK root to check for failed installs.
     print('Re-scanning {:s}...'.format(sdk))
     installed = scan(sdk, verbose=verbose)
-    missing = [p for p in packages if p not in installed]
-    if missing:
-        print('Failed to install packages:', file=sys.stderr)
-        for m in missing:
-            print('   ', m, file=sys.stderr)
-    return missing
+    return [p for p in packages if p not in installed]
 
 
 def install_packages(packages, android, options=None, verbose=False, timeout=None):
@@ -99,7 +94,7 @@ def install_packages(packages, android, options=None, verbose=False, timeout=Non
             installer.sendline('y')
         elif i == 1:
             # Timeout
-            print('Package installation timed out after {:d} seconds.'
+            print('WARNING: Package installation timed out after {:d} seconds.'
                   .format(timeout), file=sys.stderr)
             break
         else:
@@ -159,8 +154,10 @@ def main(sdk, packages=None, options=None, verbose=False, timeout=None, dry_run=
     missing = scan_missing(sdk, to_install, verbose=verbose)
 
     if missing:
-        print('Finished: {:d} packages installed. Failed to install {:d} packages.'
-              .format(len(to_install) - len(missing), len(missing)))
+        print('FATAL: Finished: {:d} packages installed. Failed to install {:d} package(s):'
+              .format(len(to_install) - len(missing), len(missing)), file=sys.stderr)
+        for p in missing:
+            print('    ', p, file=sys.stderr)
         exit(1)
     else:
         print('Finished: {:d} packages installed.'.format(len(to_install)))

--- a/sdk_updater/update.py
+++ b/sdk_updater/update.py
@@ -126,12 +126,19 @@ def main(sdk, packages=None, options=None, verbose=False, timeout=None, dry_run=
         print('{:s} not found. Is ANDROID_HOME correct?'.format(android))
         exit(1)
 
-    ops, missing = updates_available(android, sdk, packages, options, verbose)
+    ops, missing_remote = updates_available(android, sdk, packages, options, verbose)
 
-    if missing:
-        for name in missing:
-            print('Remote repository is missing package \'{:s}\''.format(name), file=sys.stderr)
-        exit(1)
+    if missing_remote:
+        print('WARNING: Remote repository is missing package(s):', file=sys.stderr)
+        for name in missing_remote:
+            print('    ', name, file=sys.stderr)
+        if packages:
+            missing_requested = set(missing_remote).intersection(set(packages))
+            if missing_requested:
+                print('FATAL: Remote repository is missing explicitly requested package(s):', file=sys.stderr)
+                for p in missing_requested:
+                    print('    ', p, file=sys.stderr)
+                exit(1)
 
     if not ops:
         print("All packages are up-to-date.")


### PR DESCRIPTION
Fixes #27

Fail only when the remote is missing packages requested explicitly via `stdin` or the command line.

cc @kylannjohnson
